### PR TITLE
Rename primary to key & keys

### DIFF
--- a/lib/Dialects/mysql.js
+++ b/lib/Dialects/mysql.js
@@ -121,11 +121,11 @@ exports.getCollectionProperties = function (db, name, cb) {
 	});
 };
 
-exports.createCollection = function (db, name, columns, primary, cb) {
+exports.createCollection = function (db, name, columns, keys, cb) {
 	return db.query(SQL.CREATE_TABLE({
 		name    : name,
 		columns : columns,
-		primary : primary
+		keys    : keys
 	}, exports), cb);
 };
 
@@ -159,7 +159,12 @@ exports.dropCollectionColumn = function (db, name, column, cb) {
 };
 
 exports.getCollectionIndexes = function (db, name, cb) {
-	db.query("SHOW INDEX FROM ??", [ name ], function (err, rows) {
+	var q = "";
+	q += "SELECT index_name, column_name, non_unique ";
+	q += "FROM information_schema.statistics ";
+	q += "WHERE table_name = ?";
+
+	db.query(q, [name], function (err, rows) {
 		if (err) return cb(err);
 
 		return cb(null, convertIndexRows(rows));
@@ -203,7 +208,7 @@ exports.getType = function (collection, name, property) {
 		case "serial":
 			property.type = "number";
 			property.serial = true;
-			property.primary = true;
+			property.key = true;
 			type = "INT(11)";
 			break;
 		case "boolean":
@@ -311,17 +316,17 @@ function convertIndexRows(rows) {
 	var indexes = {};
 
 	for (var i = 0; i < rows.length; i++) {
-		if (rows[i].Key_name == 'PRIMARY') {
+		if (rows[i].index_name == 'PRIMARY') {
 			continue;
 		}
-		if (!indexes.hasOwnProperty(rows[i].Key_name)) {
-			indexes[rows[i].Key_name] = {
+		if (!indexes.hasOwnProperty(rows[i].index_name)) {
+			indexes[rows[i].index_name] = {
 				columns : [],
-				unique  : (rows[i].Non_unique == 0)
+				unique  : (rows[i].non_unique == 0)
 			};
 		}
 
-		indexes[rows[i].Key_name].columns.push(rows[i].Column_name);
+		indexes[rows[i].index_name].columns.push(rows[i].column_name);
 	}
 
 	return indexes;

--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -87,7 +87,6 @@ exports.getCollectionProperties = function (db, name, cb) {
 						break;
 					}
 				default:
-					console.log(cols[i]);
 					return cb(new Error("Unknown column type '" + cols[i].data_type + "'"));
 			}
 
@@ -98,11 +97,11 @@ exports.getCollectionProperties = function (db, name, cb) {
 	});
 };
 
-exports.createCollection = function (db, name, columns, primary, cb) {
+exports.createCollection = function (db, name, columns, keys, cb) {
 	return db.query(SQL.CREATE_TABLE({
 		name    : name,
 		columns : columns,
-		primary : primary
+		keys    : keys
 	}, exports), cb);
 };
 
@@ -230,6 +229,7 @@ exports.getType = function (collection, name, property) {
 				break;
 			case "serial":
 				property.serial = true;
+				property.key = true;
 				type = "SERIAL";
 				break;
 			case "boolean":

--- a/lib/Dialects/sqlite.js
+++ b/lib/Dialects/sqlite.js
@@ -23,7 +23,7 @@ exports.getCollectionProperties = function (db, name, cb) {
 			var column = {};
 
 			if (cols[i].pk) {
-				column.primary = true;
+				column.key = true;
 			}
 
 			if (cols[i].notnull) {
@@ -69,11 +69,11 @@ exports.getCollectionProperties = function (db, name, cb) {
 	});
 };
 
-exports.createCollection = function (db, name, columns, primary, cb) {
+exports.createCollection = function (db, name, columns, keys, cb) {
 	return db.all(SQL.CREATE_TABLE({
 		name    : name,
 		columns : columns,
-		primary : primary
+		keys    : keys
 	}, exports), cb);
 };
 
@@ -148,12 +148,12 @@ exports.removeIndex = function (db, name, collection, cb) {
 	return db.all("DROP INDEX IF EXISTS " + exports.escapeId(name), cb);
 };
 
-exports.checkPrimary = function (primary) {
-	if (primary.length === 1) {
+exports.processKeys = function (keys) {
+	if (keys.length === 1) {
 		return [];
 	}
 
-	return primary;
+	return keys;
 };
 
 exports.supportsType = function (type) {
@@ -181,7 +181,7 @@ exports.getType = function (collection, name, property) {
 			break;
 		case "serial":
 			property.serial = true;
-			property.primary = true;
+			property.key = true;
 			type = "INTEGER";
 			break;
 		case "boolean":
@@ -207,7 +207,7 @@ exports.getType = function (collection, name, property) {
 	if (property.required) {
 		type += " NOT NULL";
 	}
-	if (property.primary) {
+	if (property.key) {
 		if (!property.required) {
 			// append if not set
 			type += " NOT NULL";
@@ -217,7 +217,7 @@ exports.getType = function (collection, name, property) {
 		}
 	}
 	if (property.serial) {
-		if (!property.primary) {
+		if (!property.key) {
 			type += " PRIMARY KEY";
 		}
 		type += " AUTOINCREMENT";

--- a/lib/SQL.js
+++ b/lib/SQL.js
@@ -1,8 +1,8 @@
 exports.CREATE_TABLE = function (options, dialect) {
 	var sql = "CREATE TABLE " + dialect.escapeId(options.name) + " (" + options.columns.join(", ");
 
-	if (options.primary && options.primary.length > 0) {
-		sql += ", PRIMARY KEY (" + options.primary.map(function (val) {
+	if (options.keys && options.keys.length > 0) {
+		sql += ", PRIMARY KEY (" + options.keys.map(function (val) {
 			return dialect.escapeId(val);
 		}).join(", ") + ")";
 	}

--- a/lib/Sync.js
+++ b/lib/Sync.js
@@ -35,11 +35,11 @@ function Sync(options) {
 
 	var createCollection = function (collection, cb) {
 		var columns = [];
-		var primary = [];
+		var keys = [];
 		var before  = [];
 		var nextBefore = function () {
 			if (before.length === 0) {
-				return Dialect.createCollection(db, collection.name, columns, primary, function () {
+				return Dialect.createCollection(db, collection.name, columns, keys, function () {
 					return syncIndexes(collection.name, getCollectionIndexes(collection), cb);
 				});
 			}
@@ -62,8 +62,8 @@ function Sync(options) {
 				return cb(new Error("Unknown type for property '" + k + "'"));
 			}
 
-			if (collection.properties[k].primary) {
-				primary.push(k);
+			if (collection.properties[k].key) {
+				keys.push(k);
 			}
 
 			columns.push(col.value);
@@ -75,8 +75,8 @@ function Sync(options) {
 
 		debug("Creating " + collection.name);
 
-		if (typeof Dialect.checkPrimary == "function") {
-			primary = Dialect.checkPrimary(primary);
+		if (typeof Dialect.processKeys == "function") {
+			keys = Dialect.processKeys(keys);
 		}
 
 		total_changes += 1;
@@ -325,7 +325,7 @@ function Sync(options) {
 		if (property.type == "serial") {
 			return false; // serial columns have a fixed form, nothing more to check
 		}
-		if (property.required != column.required && !property.primary) {
+		if (property.required != column.required && !property.key) {
 			return true;
 		}
 		if (property.hasOwnProperty("defaultValue") && property.defaultValue != column.defaultValue) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name"            : "sql-ddl-sync",
 	"description"     : "NodeJS SQL DDL Synchronization",
 	"keywords"        : [ "sql", "ddl", "sync", "mysql", "postgres", "sqlite" ],
-	"version"         : "0.1.4",
+	"version"         : "0.1.5",
 	"license"         : "MIT",
 	"repository"      : "http://github.com/dresende/node-sql-ddl-sync.git",
 	"main"            : "./lib/Sync",

--- a/test/integration/db.js
+++ b/test/integration/db.js
@@ -10,7 +10,7 @@ var sync    = new Sync({
 });
 
 sync.defineCollection(common.table, {
-	id     : { type: "number", primary: true, serial: true },
+	id     : { type: "number", key: true, serial: true },
 	name   : { type: "text", required: true, defaultValue: 'John' },
 	age    : { type: "number", rational: true },
 	male   : { type: "boolean" },

--- a/test/integration/sql.js
+++ b/test/integration/sql.js
@@ -10,7 +10,7 @@ describe("SQL.CREATE_TABLE", function () {
 		SQL.CREATE_TABLE({
 			name    : "fake_table",
 			columns : [ "first_fake_column", "second_fake_column" ],
-			primary : [ "my_primary_key" ]
+			keys    : [ "my_primary_key" ]
 		}, Dialect).should.equal("CREATE TABLE $$fake_table$$ (first_fake_column, second_fake_column, " +
 		                         "PRIMARY KEY ($$my_primary_key$$))");
 


### PR DESCRIPTION
Key properties are marked by setting `property.key = true` in orm2.
This change applies the same naming convention here.

Also, in certain places, `primary` was an array rather than a boolean property.
I renamed it to `keys` to make the code easier to read.
