### PR TITLE
Hijack sql-ddl-sync to integrate better into ORM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - '0.6'
   - '0.8'
   - '0.10'

--- a/README.md
+++ b/README.md
@@ -17,53 +17,58 @@ npm install sql-ddl-sync
 
 ## About
 
-This module is used by [ORM](http://dresende.github.com/node-orm2) to synchronize model tables in the different supported
-dialects. Sorry there is no API documentation for now but there are a couple of tests you can read and find out how to use
-it if you want.
+This module is part of [ORM](http://dresende.github.com/node-orm2). It's used synchronize model tables in supported dialects.
+Sorry there is no API documentation for now but there are a couple of tests you can read and find out how to use it if you want.
 
 ## Example
 
-Install module and install `mysql`, create a file with the contents below and change line 2 to match valid credentials.
+Install `orm` & the required driver (eg: `mysql`).
+Create a file with the contents below and change insert your database credentials.
 Run once and you'll see table `ddl_sync_test` appear in your database. Then make some changes to it (add/drop/change columns)
 and run the code again. Your table should always return to the same structure.
 
 ```js
-var mysql = require("mysql");
-var db    = mysql.createConnection("mysql://username:password@localhost/database");
+var orm    = require("orm");
+var mysql  = require("mysql");
+var Sync   = require("sql-ddl-sync").Sync;
 
-var Sync = require("sql-ddl-sync").Sync;
-var sync = new Sync({
-	dialect : "mysql",
-	db      : db,
-	debug   : function (text) {
-		console.log("> %s", text);
-	}
-});
+orm.connect("mysql://username:password@localhost/database", function (err, db) {
+	if (err) throw err;
+	var driver = db.driver;
 
-sync.defineCollection("ddl_sync_test", {
-	id     : { type : "number", primary: true, serial: true },
-	name   : { type : "text", required: true },
-	age    : { type : "number", rational: true },
-	male   : { type : "boolean" },
-	born   : { type : "date", time: true },
-	born2  : { type : "date" },
-	int2   : { type : "number", size: 2 },
-	int4   : { type : "number", size: 4 },
-	int8   : { type : "number", size: 8 },
-	float4 : { type : "number", rational: true, size: 4 },
-	float8 : { type : "number", rational: true, size: 8 },
-	type   : { type : "enum", values: [ 'dog', 'cat'], defaultValue: 'dog', required: true },
-	photo  : { type : "binary" }
-});
+	var sync = new Sync({
+		dialect : "mysql",
+		driver  : driver,
+		debug   : function (text) {
+			console.log("> %s", text);
+		}
+	});
 
-sync.sync(function (err) {
-	if (err) {
-		console.log("> Sync Error");
-		console.log(err);
-	} else {
-		console.log("> Sync Done");
-	}
-	process.exit(0);
+	sync.defineCollection("ddl_sync_test", {
+		id     : { type : "number", primary: true, serial: true },
+		name   : { type : "text", required: true },
+		age    : { type : "number", rational: true },
+		male   : { type : "boolean" },
+		born   : { type : "date", time: true },
+		born2  : { type : "date" },
+		int2   : { type : "number", size: 2 },
+		int4   : { type : "number", size: 4 },
+		int8   : { type : "number", size: 8 },
+		float4 : { type : "number", rational: true, size: 4 },
+		float8 : { type : "number", rational: true, size: 8 },
+		type   : { type : "enum", values: [ 'dog', 'cat'], defaultValue: 'dog', required: true },
+		photo  : { type : "binary" }
+	});
+
+	sync.sync(function (err) {
+		if (err) {
+			console.log("> Sync Error");
+			console.log(err);
+		} else {
+			console.log("> Sync Done");
+		}
+		process.exit(0);
+	});
 });
 
 ```

--- a/lib/Dialects/mysql.js
+++ b/lib/Dialects/mysql.js
@@ -6,16 +6,16 @@ var columnSizes = {
 	floating: {                4: 'FLOAT',   8: 'DOUBLE' }
 };
 
-exports.hasCollection = function (db, name, cb) {
-	db.query("SHOW TABLES LIKE ?", [ name ], function (err, rows) {
+exports.hasCollection = function (driver, name, cb) {
+	driver.execQuery("SHOW TABLES LIKE ?", [ name ], function (err, rows) {
 		if (err) return cb(err);
 
 		return cb(null, rows.length > 0);
 	});
 };
 
-exports.getCollectionProperties = function (db, name, cb) {
-	db.query("SHOW COLUMNS FROM ??", [ name ], function (err, cols) {
+exports.getCollectionProperties = function (driver, name, cb) {
+	driver.execQuery("SHOW COLUMNS FROM ??", [ name ], function (err, cols) {
 		if (err) return cb(err);
 
 		var columns = {}, m;
@@ -121,73 +121,73 @@ exports.getCollectionProperties = function (db, name, cb) {
 	});
 };
 
-exports.createCollection = function (db, name, columns, keys, cb) {
-	return db.query(SQL.CREATE_TABLE({
+exports.createCollection = function (driver, name, columns, keys, cb) {
+	return driver.execQuery(SQL.CREATE_TABLE({
 		name    : name,
 		columns : columns,
 		keys    : keys
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.dropCollection = function (db, name, cb) {
-	return db.query(SQL.DROP_TABLE({
+exports.dropCollection = function (driver, name, cb) {
+	return driver.execQuery(SQL.DROP_TABLE({
 		name    : name
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.addCollectionColumn = function (db, name, column, after_column, cb) {
-	return db.query(SQL.ALTER_TABLE_ADD_COLUMN({
+exports.addCollectionColumn = function (driver, name, column, after_column, cb) {
+	return driver.execQuery(SQL.ALTER_TABLE_ADD_COLUMN({
 		name   : name,
 		column : column,
 		after  : after_column,
 		first  : !after_column
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.modifyCollectionColumn = function (db, name, column, cb) {
-	return db.query(SQL.ALTER_TABLE_MODIFY_COLUMN({
+exports.modifyCollectionColumn = function (driver, name, column, cb) {
+	return driver.execQuery(SQL.ALTER_TABLE_MODIFY_COLUMN({
 		name        : name,
 		column      : column
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.dropCollectionColumn = function (db, name, column, cb) {
-	return db.query(SQL.ALTER_TABLE_DROP_COLUMN({
+exports.dropCollectionColumn = function (driver, name, column, cb) {
+	return driver.execQuery(SQL.ALTER_TABLE_DROP_COLUMN({
 		name        : name,
 		column      : column
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.getCollectionIndexes = function (db, name, cb) {
+exports.getCollectionIndexes = function (driver, name, cb) {
 	var q = "";
 	q += "SELECT index_name, column_name, non_unique ";
 	q += "FROM information_schema.statistics ";
 	q += "WHERE table_name = ?";
 
-	db.query(q, [name], function (err, rows) {
+	driver.execQuery(q, [name], function (err, rows) {
 		if (err) return cb(err);
 
 		return cb(null, convertIndexRows(rows));
 	});
 };
 
-exports.addIndex = function (db, name, unique, collection, columns, cb) {
-	return db.query(SQL.CREATE_INDEX({
+exports.addIndex = function (driver, name, unique, collection, columns, cb) {
+	return driver.execQuery(SQL.CREATE_INDEX({
 		name       : name,
 		unique     : unique,
 		collection : collection,
 		columns    : columns
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.removeIndex = function (db, name, collection, cb) {
-	return db.query(SQL.DROP_INDEX({
+exports.removeIndex = function (driver, name, collection, cb) {
+	return driver.execQuery(SQL.DROP_INDEX({
 		name       : name,
 		collection : collection
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.getType = function (collection, name, property) {
+exports.getType = function (collection, name, property, driver) {
 	var type = false;
 
 	switch (property.type) {
@@ -230,7 +230,7 @@ exports.getType = function (collection, name, property) {
 			}
 			break;
 		case "enum":
-			type = "ENUM (" + property.values.map(exports.escapeVal) + ")";
+			type = "ENUM (" + property.values.map(driver.query.escapeVal) + ")";
 			break;
 		case "point":
 			type = "POINT";
@@ -250,66 +250,13 @@ exports.getType = function (collection, name, property) {
 		type += " AUTO_INCREMENT";
 	}
 	if (property.hasOwnProperty("defaultValue")) {
-		type += " DEFAULT " + exports.escapeVal(property.defaultValue);
+		type += " DEFAULT " + driver.query.escapeVal(property.defaultValue);
 	}
 
 	return {
 		value  : type,
 		before : false
 	};
-};
-
-exports.escapeId = function () {
-	return Array.prototype.slice.apply(arguments).map(function (el) {
-		return "`" + el.replace(/`/g, '``') + "`";
-	}).join(".");
-};
-
-exports.escapeVal = function (val, timeZone) {
-	if (val === undefined || val === null) {
-		return 'NULL';
-	}
-
-	if (Buffer.isBuffer(val)) {
-		return bufferToString(val);
-	}
-
-	if (Array.isArray(val)) {
-		return arrayToList(val, timeZone || "local");
-	}
-
-	if (util.isDate(val)) {
-		val = dateToString(val, timeZone || "local");
-	} else {
-		switch (typeof val) {
-			case 'boolean':
-				return (val) ? 'true' : 'false';
-			case 'number':
-				if (!isFinite(val)) {
-					val = val.toString();
-					break;
-				}
-				return val + '';
-			case "object":
-				return objectToValues(val, timeZone || "local");
-			case "function":
-				return val(exports);
-		}
-	}
-
-	val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
-		switch(s) {
-			case "\0": return "\\0";
-			case "\n": return "\\n";
-			case "\r": return "\\r";
-			case "\b": return "\\b";
-			case "\t": return "\\t";
-			case "\x1a": return "\\Z";
-			default: return "\\" + s;
-		}
-	});
-
-	return "'" + val + "'";
 };
 
 function convertIndexRows(rows) {
@@ -330,28 +277,6 @@ function convertIndexRows(rows) {
 	}
 
 	return indexes;
-}
-
-function objectToValues(object, timeZone) {
-	var values = [];
-	for (var key in object) {
-		var value = object[key];
-
-		if(typeof value === 'function') {
-			continue;
-		}
-
-		values.push(exports.escapeId(key) + ' = ' + exports.escapeVal(value, timeZone));
-	}
-
-	return values.join(', ');
-}
-
-function arrayToList(array, timeZone) {
-	return "(" + array.map(function(v) {
-		if (Array.isArray(v)) return arrayToList(v);
-		return exports.escapeVal(v, timeZone);
-	}).join(', ') + ")";
 }
 
 function bufferToString(buffer) {

--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -6,19 +6,18 @@ var columnSizes = {
 	floating: {                4: 'REAL',    8: 'DOUBLE PRECISION' }
 };
 
-exports.hasCollection = function (db, name, cb) {
-	db.query("SELECT * FROM information_schema.tables WHERE table_name = $1", [ name ], function (err, result) {
+exports.hasCollection = function (driver, name, cb) {
+	driver.execQuery("SELECT * FROM information_schema.tables WHERE table_name = ?", [ name ], function (err, rows) {
 		if (err) return cb(err);
 
-		return cb(null, result.rows.length > 0);
+		return cb(null, rows.length > 0);
 	});
 };
 
-exports.getCollectionProperties = function (db, name, cb) {
-	db.query("SELECT * FROM information_schema.columns WHERE table_name = $1", [ name ], function (err, result) {
+exports.getCollectionProperties = function (driver, name, cb) {
+	driver.execQuery("SELECT * FROM information_schema.columns WHERE table_name = ?", [ name ], function (err, cols) {
 		if (err) return cb(err);
 
-		var cols    = result.rows;
 		var columns = {}, m;
 
 		for (var i = 0; i < cols.length; i++) {
@@ -93,31 +92,33 @@ exports.getCollectionProperties = function (db, name, cb) {
 			columns[cols[i].column_name] = column;
 		}
 
-		return checkColumnTypes(db, name, columns, cb);
+		return checkColumnTypes(driver, name, columns, cb);
 	});
 };
 
-exports.createCollection = function (db, name, columns, keys, cb) {
-	return db.query(SQL.CREATE_TABLE({
+exports.createCollection = function (driver, name, columns, keys, cb) {
+	return driver.execQuery(SQL.CREATE_TABLE({
+		driver  : driver,
 		name    : name,
 		columns : columns,
 		keys    : keys
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.dropCollection = function (db, name, cb) {
-	return db.query(SQL.DROP_TABLE({
+exports.dropCollection = function (driver, name, cb) {
+	return driver.execQuery(SQL.DROP_TABLE({
+		driver  : driver,
 		name    : name
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.addCollectionColumn = function (db, name, column, after_column, cb) {
-	var sql = "ALTER TABLE " + exports.escapeId(name) + " ADD " + column;
+exports.addCollectionColumn = function (driver, name, column, after_column, cb) {
+	var sql = "ALTER TABLE " + driver.query.escapeId(name) + " ADD " + column;
 
-	return db.query(sql, cb);
+	return driver.execQuery(sql, cb);
 };
 
-exports.modifyCollectionColumn = function (db, name, column, cb) {
+exports.modifyCollectionColumn = function (driver, name, column, cb) {
 	var p        = column.indexOf(" ");
 	var col_name = column.substr(0, p);
 	var queue    = new Queue(cb);
@@ -135,7 +136,7 @@ exports.modifyCollectionColumn = function (db, name, column, cb) {
 	}
 
 	queue.add(function (next) {
-		return db.query("ALTER TABLE " + name +
+		return driver.execQuery("ALTER TABLE " + name +
 		                " ALTER " + col_name +
 		                " TYPE " + col_type, next);
 	});
@@ -143,13 +144,13 @@ exports.modifyCollectionColumn = function (db, name, column, cb) {
 	if (column) {
 		if (column.match(/NOT NULL/)) {
 			queue.add(function (next) {
-				return db.query("ALTER TABLE " + name +
+				return driver.execQuery("ALTER TABLE " + name +
 				                " ALTER " + col_name +
 				                " SET NOT NULL", next);
 			});
 		} else {
 			queue.add(function (next) {
-				return db.query("ALTER TABLE " + name +
+				return driver.execQuery("ALTER TABLE " + name +
 				                " ALTER " + col_name +
 				                " DROP NOT NULL", next);
 			});
@@ -157,7 +158,7 @@ exports.modifyCollectionColumn = function (db, name, column, cb) {
 
 		if (m = column.match(/DEFAULT (.+)$/)) {
 			queue.add(function (next) {
-				return db.query("ALTER TABLE " + name +
+				return driver.execQuery("ALTER TABLE " + name +
 				                " ALTER " + col_name +
 				                " SET DEFAULT " + m[1], next);
 			});
@@ -167,38 +168,40 @@ exports.modifyCollectionColumn = function (db, name, column, cb) {
 	return queue.check();
 };
 
-exports.dropCollectionColumn = function (db, name, column, cb) {
-	return db.query(SQL.ALTER_TABLE_DROP_COLUMN({
+exports.dropCollectionColumn = function (driver, name, column, cb) {
+	return driver.execQuery(SQL.ALTER_TABLE_DROP_COLUMN({
+		driver     : driver,
 		name        : name,
 		column      : column
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.getCollectionIndexes = function (db, name, cb) {
-	db.query("SELECT t.relname, i.relname, a.attname, ix.indisunique, ix.indisprimary " +
+exports.getCollectionIndexes = function (driver, name, cb) {
+	driver.execQuery("SELECT t.relname, i.relname, a.attname, ix.indisunique, ix.indisprimary " +
 	         "FROM pg_class t, pg_class i, pg_index ix, pg_attribute a " +
 	         "WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid " +
 	         "AND a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) " +
-	         "AND t.relkind = 'r' AND t.relname = $1",
+	         "AND t.relkind = 'r' AND t.relname = ?",
 	         [ name ],
-	function (err, result) {
+	function (err, rows) {
 		if (err) return cb(err);
 
-		return cb(null, convertIndexRows(result.rows));
+		return cb(null, convertIndexRows(rows));
 	});
 };
 
-exports.addIndex = function (db, name, unique, collection, columns, cb) {
-	return db.query(SQL.CREATE_INDEX({
+exports.addIndex = function (driver, name, unique, collection, columns, cb) {
+	return driver.execQuery(SQL.CREATE_INDEX({
+		driver     : driver,
 		name       : name,
 		unique     : unique,
 		collection : collection,
 		columns    : columns
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.removeIndex = function (db, name, collection, cb) {
-	return db.query("DROP INDEX " + exports.escapeId(name), cb);
+exports.removeIndex = function (driver, name, collection, cb) {
+	return driver.execQuery("DROP INDEX " + driver.query.escapeId(name), cb);
 };
 
 exports.convertIndexes = function (collection, indexes) {
@@ -209,7 +212,7 @@ exports.convertIndexes = function (collection, indexes) {
 	return indexes;
 };
 
-exports.getType = function (collection, name, property) {
+exports.getType = function (collection, name, property, driver) {
 	var type   = false;
 	var before = false;
 
@@ -248,19 +251,19 @@ exports.getType = function (collection, name, property) {
 				break;
 			case "enum":
 				type   = collection + "_enum_" + name.toLowerCase();
-				before = function (db, cb) {
+				before = function (driver, cb) {
 					var type = collection + "_enum_" + name.toLowerCase();
 
-					db.query("SELECT * FROM pg_catalog.pg_type WHERE typname = $1", [ type ], function (err, result) {
-						if (!err && result.rows.length) {
+					driver.execQuery("SELECT * FROM pg_catalog.pg_type WHERE typname = ?", [ type ], function (err, rows) {
+						if (!err && rows.length) {
 							return cb();
 						}
 
 						var values = property.values.map(function (val) {
-							return exports.escapeVal(val);
+							return driver.query.escapeVal(val);
 						});
 
-						return db.query("CREATE TYPE " + type + " " +
+						return driver.execQuery("CREATE TYPE " + type + " " +
 						                "AS ENUM (" + values + ")", cb);
 					});
 				};
@@ -281,7 +284,7 @@ exports.getType = function (collection, name, property) {
 			type += " NOT NULL";
 		}
 		if (property.hasOwnProperty("defaultValue")) {
-			type += " DEFAULT " + exports.escapeVal(property.defaultValue);
+			type += " DEFAULT " + driver.query.escapeVal(property.defaultValue);
 		}
 	}
 
@@ -289,51 +292,6 @@ exports.getType = function (collection, name, property) {
 		value  : type,
 		before : before
 	};
-};
-
-exports.escapeId = function () {
-	return Array.prototype.slice.apply(arguments).map(function (el) {
-		return el.split(".").map(function (ele) {
-			return "\"" + ele.replace(/\"/g, "\"\"") + "\"";
-		}).join(".");
-	}).join(".");
-};
-
-exports.escapeVal = function (val, timeZone) {
-	if (val === undefined || val === null) {
-		return 'NULL';
-	}
-
-	if (Array.isArray(val)) {
-		if (val.length === 1 && Array.isArray(val[0])) {
-			return "(" + val[0].map(exports.escapeVal.bind(this)) + ")";
-		}
-		return "(" + val.map(exports.escapeVal.bind(this)).join(", ") + ")";
-	}
-
-	if (util.isDate(val)) {
-		return "'" + dateToString(val, timeZone || "local") + "'";
-	}
-
-	if (Buffer.isBuffer(val)) {
-		return "'\\x" + val.toString("hex") + "'";
-	}
-
-	switch (typeof val) {
-		case "number":
-			if (!isFinite(val)) {
-				val = val.toString();
-				break;
-			}
-			return val;
-		case "boolean":
-			return val ? "true" : "false";
-		case "function":
-			return val(exports);
-	}
-	// No need to escape backslashes with default PostgreSQL 9.1+ config.
-	// Google 'postgresql standard_conforming_strings' for details.
-	return "'" + val.replace(/\'/g, "''") + "'";
 };
 
 function convertIndexRows(rows) {
@@ -357,7 +315,7 @@ function convertIndexRows(rows) {
 	return indexes;
 }
 
-function checkColumnTypes(db, collection, columns, cb) {
+function checkColumnTypes(driver, collection, columns, cb) {
 	var queue = new Queue(function () {
 		return cb(null, columns);
 	});
@@ -367,15 +325,15 @@ function checkColumnTypes(db, collection, columns, cb) {
 			queue.add(k, columns[k], function (name, col, next) {
 				var col_name = collection + "_enum_" + name;
 
-				db.query("SELECT t.typname, string_agg(e.enumlabel, '|' ORDER BY e.enumsortorder) AS enum_values " +
+				driver.execQuery("SELECT t.typname, string_agg(e.enumlabel, '|' ORDER BY e.enumsortorder) AS enum_values " +
 				         "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid = e.enumtypid  " +
-				         "WHERE t.typname = $1 GROUP BY 1", [ col_name ],
-				function (err, result) {
+				         "WHERE t.typname = ? GROUP BY 1", [ col_name ],
+				function (err, rows) {
 					if (err) {
 						return next(err);
 					}
-					if (result.rows.length) {
-						col.values = result.rows[0].enum_values.split("|");
+					if (rows.length) {
+						col.values = rows[0].enum_values.split("|");
 					}
 
 					return next();

--- a/lib/Dialects/sqlite.js
+++ b/lib/Dialects/sqlite.js
@@ -2,8 +2,8 @@ var Queue = require("../Queue").Queue;
 var SQL   = require("../SQL");
 var util  = require("util");
 
-exports.hasCollection = function (db, name, cb) {
-	db.all("SELECT * FROM sqlite_master " +
+exports.hasCollection = function (driver, name, cb) {
+	driver.execQuery("SELECT * FROM sqlite_master " +
 	       "WHERE type = 'table' and name = ?",
 	       [ name ],
 	function (err, rows) {
@@ -13,8 +13,8 @@ exports.hasCollection = function (db, name, cb) {
 	});
 };
 
-exports.getCollectionProperties = function (db, name, cb) {
-	db.all("PRAGMA table_info(" + exports.escapeId(name) + ")", function (err, cols) {
+exports.getCollectionProperties = function (driver, name, cb) {
+	driver.execQuery("PRAGMA table_info(" + driver.query.escapeId(name) + ")", function (err, cols) {
 		if (err) return cb(err);
 
 		var columns = {}, m;
@@ -69,43 +69,43 @@ exports.getCollectionProperties = function (db, name, cb) {
 	});
 };
 
-exports.createCollection = function (db, name, columns, keys, cb) {
-	return db.all(SQL.CREATE_TABLE({
+exports.createCollection = function (driver, name, columns, keys, cb) {
+	return driver.execQuery(SQL.CREATE_TABLE({
 		name    : name,
 		columns : columns,
 		keys    : keys
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.dropCollection = function (db, name, cb) {
-	return db.all(SQL.DROP_TABLE({
+exports.dropCollection = function (driver, name, cb) {
+	return driver.execQuery(SQL.DROP_TABLE({
 		name    : name
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.addCollectionColumn = function (db, name, column, after_column, cb) {
-	return db.all(SQL.ALTER_TABLE_ADD_COLUMN({
+exports.addCollectionColumn = function (driver, name, column, after_column, cb) {
+	return driver.execQuery(SQL.ALTER_TABLE_ADD_COLUMN({
 		name   : name,
 		column : column,
 		after  : after_column,
 		first  : !after_column
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.modifyCollectionColumn = function (db, name, column, cb) {
-	return db.all(SQL.ALTER_TABLE_MODIFY_COLUMN({
+exports.modifyCollectionColumn = function (driver, name, column, cb) {
+	return driver.execQuery(SQL.ALTER_TABLE_MODIFY_COLUMN({
 		name        : name,
 		column      : column
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.dropCollectionColumn = function (db, name, column, cb) {
+exports.dropCollectionColumn = function (driver, name, column, cb) {
 	// sqlite does not support dropping columns
 	return cb();
 };
 
-exports.getCollectionIndexes = function (db, name, cb) {
-	db.all("PRAGMA index_list(" + exports.escapeId(name) + ")", function (err, rows) {
+exports.getCollectionIndexes = function (driver, name, cb) {
+	driver.execQuery("PRAGMA index_list(" + driver.query.escapeId(name) + ")", function (err, rows) {
 		if (err) return cb(err);
 
 		var indexes = convertIndexRows(rows);
@@ -119,7 +119,7 @@ exports.getCollectionIndexes = function (db, name, cb) {
 				continue;
 			}
 			queue.add(k, function (k, next) {
-				db.all("PRAGMA index_info(" + exports.escapeVal(k) + ")", function (err, rows) {
+				driver.execQuery("PRAGMA index_info(" + driver.query.escapeVal(k) + ")", function (err, rows) {
 					if (err) return next(err);
 
 					for (var i = 0; i < rows.length; i++) {
@@ -135,17 +135,17 @@ exports.getCollectionIndexes = function (db, name, cb) {
 	});
 };
 
-exports.addIndex = function (db, name, unique, collection, columns, cb) {
-	return db.all(SQL.CREATE_INDEX({
+exports.addIndex = function (driver, name, unique, collection, columns, cb) {
+	return driver.execQuery(SQL.CREATE_INDEX({
 		name       : name,
 		unique     : unique,
 		collection : collection,
 		columns    : columns
-	}, exports), cb);
+	}, driver), cb);
 };
 
-exports.removeIndex = function (db, name, collection, cb) {
-	return db.all("DROP INDEX IF EXISTS " + exports.escapeId(name), cb);
+exports.removeIndex = function (driver, name, collection, cb) {
+	return driver.execQuery("DROP INDEX IF EXISTS " + driver.query.escapeId(name), cb);
 };
 
 exports.processKeys = function (keys) {
@@ -165,7 +165,7 @@ exports.supportsType = function (type) {
 	return type;
 };
 
-exports.getType = function (collection, name, property) {
+exports.getType = function (collection, name, property, driver) {
 	var type = false;
 
 	switch (property.type) {
@@ -223,57 +223,13 @@ exports.getType = function (collection, name, property) {
 		type += " AUTOINCREMENT";
 	}
 	if (property.hasOwnProperty("defaultValue")) {
-		type += " DEFAULT " + exports.escapeVal(property.defaultValue);
+		type += " DEFAULT " + driver.query.escapeVal(property.defaultValue);
 	}
 
 	return {
 		value  : type,
 		before : false
 	};
-};
-
-exports.escapeId = function () {
-	return Array.prototype.slice.apply(arguments).map(function (el) {
-		return "`" + el.replace(/`/g, '``') + "`";
-	}).join(".");
-};
-
-exports.escapeVal = function (val, timeZone) {
-	if (val === undefined || val === null) {
-		return 'NULL';
-	}
-
-	if (Array.isArray(val)) {
-		if (val.length === 1 && Array.isArray(val[0])) {
-			return "(" + val[0].map(exports.escapeVal.bind(this)) + ")";
-		}
-		return "(" + val.map(exports.escapeVal.bind(this)).join(", ") + ")";
-	}
-
-	if (util.isDate(val)) {
-		return "'" + dateToString(val, timeZone || "local") + "'";
-	}
-
-	if (Buffer.isBuffer(val)) {
-		return "X'" + val.toString("hex") + "'";
-	}
-
-	switch (typeof val) {
-		case "number":
-			if (!isFinite(val)) {
-				val = val.toString();
-				break;
-			}
-			return val;
-		case "boolean":
-			return val ? 1 : 0;
-		case "function":
-			return val(exports);
-	}
-
-	// No need to escape backslashes with default PostgreSQL 9.1+ config.
-	// Google 'postgresql standard_conforming_strings' for details.
-	return "'" + val.replace(/\'/g, "''") + "'";
 };
 
 function convertIndexRows(rows) {

--- a/lib/SQL.js
+++ b/lib/SQL.js
@@ -1,9 +1,9 @@
-exports.CREATE_TABLE = function (options, dialect) {
-	var sql = "CREATE TABLE " + dialect.escapeId(options.name) + " (" + options.columns.join(", ");
+exports.CREATE_TABLE = function (options, driver) {
+	var sql = "CREATE TABLE " + driver.query.escapeId(options.name) + " (" + options.columns.join(", ");
 
 	if (options.keys && options.keys.length > 0) {
 		sql += ", PRIMARY KEY (" + options.keys.map(function (val) {
-			return dialect.escapeId(val);
+			return driver.query.escapeId(val);
 		}).join(", ") + ")";
 	}
 
@@ -12,18 +12,18 @@ exports.CREATE_TABLE = function (options, dialect) {
 	return sql;
 };
 
-exports.DROP_TABLE = function (options, dialect) {
-	var sql = "DROP TABLE " + dialect.escapeId(options.name);
+exports.DROP_TABLE = function (options, driver) {
+	var sql = "DROP TABLE " + driver.query.escapeId(options.name);
 
 	return sql;
 };
 
-exports.ALTER_TABLE_ADD_COLUMN = function (options, dialect) {
-	var sql = "ALTER TABLE " + dialect.escapeId(options.name) +
+exports.ALTER_TABLE_ADD_COLUMN = function (options, driver) {
+	var sql = "ALTER TABLE " + driver.query.escapeId(options.name) +
 	          " ADD " + options.column;
 
 	if (options.after) {
-		sql += " AFTER " + dialect.escapeId(options.after);
+		sql += " AFTER " + driver.query.escapeId(options.after);
 	} else if (options.first) {
 		sql += " FIRST";
 	}
@@ -31,31 +31,31 @@ exports.ALTER_TABLE_ADD_COLUMN = function (options, dialect) {
 	return sql;
 };
 
-exports.ALTER_TABLE_MODIFY_COLUMN = function (options, dialect) {
-	var sql = "ALTER TABLE " + dialect.escapeId(options.name) +
+exports.ALTER_TABLE_MODIFY_COLUMN = function (options, driver) {
+	var sql = "ALTER TABLE " + driver.query.escapeId(options.name) +
 	          " MODIFY " + options.column;
 
 	return sql;
 };
 
-exports.ALTER_TABLE_DROP_COLUMN = function (options, dialect) {
-	var sql = "ALTER TABLE " + dialect.escapeId(options.name) +
-	          " DROP " + dialect.escapeId(options.column);
+exports.ALTER_TABLE_DROP_COLUMN = function (options, driver) {
+	var sql = "ALTER TABLE " + driver.query.escapeId(options.name) +
+	          " DROP " + driver.query.escapeId(options.column);
 
 	return sql;
 };
 
-exports.CREATE_INDEX = function (options, dialect) {
-	var sql = "CREATE" + (options.unique ? " UNIQUE" : "") + " INDEX " + dialect.escapeId(options.name) +
-	          " ON " + dialect.escapeId(options.collection) +
-	          " (" + options.columns.map(function (col) { return dialect.escapeId(col); }) + ")";
+exports.CREATE_INDEX = function (options, driver) {
+	var sql = "CREATE" + (options.unique ? " UNIQUE" : "") + " INDEX " + driver.query.escapeId(options.name) +
+	          " ON " + driver.query.escapeId(options.collection) +
+	          " (" + options.columns.map(function (col) { return driver.query.escapeId(col); }) + ")";
 
 	return sql;
 };
 
-exports.DROP_INDEX = function (options, dialect) {
-	var sql = "DROP INDEX " + dialect.escapeId(options.name) +
-	          " ON " + dialect.escapeId(options.collection);
+exports.DROP_INDEX = function (options, driver) {
+	var sql = "DROP INDEX " + driver.query.escapeId(options.name) +
+	          " ON " + driver.query.escapeId(options.collection);
 
 	return sql;
 };

--- a/lib/Sync.js
+++ b/lib/Sync.js
@@ -5,16 +5,16 @@ var _     = require("lodash");
 exports.Sync = Sync;
 
 function Sync(options) {
-	var Dialect     = require("./Dialects/" + options.dialect);
 	var debug       = options.debug || noOp;
-	var db          = options.db;
-    var suppressColumnDrop = options.suppressColumnDrop;
+	var driver      = options.driver;
+	var Dialect     = require("./Dialects/" + driver.dialect);
+	var suppressColumnDrop = options.suppressColumnDrop;
 	var collections = [];
 	var types       = {};
 	var total_changes;
 
 	var processCollection = function (collection, cb) {
-		Dialect.hasCollection(db, collection.name, function (err, has) {
+		Dialect.hasCollection(driver, collection.name, function (err, has) {
 			if (err) {
 				return cb(err);
 			}
@@ -23,7 +23,7 @@ function Sync(options) {
 				return createCollection(collection, cb);
 			}
 
-			Dialect.getCollectionProperties(db, collection.name, function (err, columns) {
+			Dialect.getCollectionProperties(driver, collection.name, function (err, columns) {
 				if (err) {
 					return cb(err);
 				}
@@ -39,14 +39,14 @@ function Sync(options) {
 		var before  = [];
 		var nextBefore = function () {
 			if (before.length === 0) {
-				return Dialect.createCollection(db, collection.name, columns, keys, function () {
+				return Dialect.createCollection(driver, collection.name, columns, keys, function () {
 					return syncIndexes(collection.name, getCollectionIndexes(collection), cb);
 				});
 			}
 
 			var next = before.shift();
 
-			next(db, function (err) {
+			next(driver, function (err) {
 				if (err) {
 					return cb(err);
 				}
@@ -87,7 +87,7 @@ function Sync(options) {
 	var createColumn = function (collection, name, property) {
 		var type = types.hasOwnProperty(property.type)
 		         ? types[property.type].datastoreType(property)
-		         : Dialect.getType(collection, name, property);
+		         : Dialect.getType(collection, name, property, driver);
 
 		if (type === false) {
 			return false;
@@ -97,7 +97,7 @@ function Sync(options) {
 		}
 
 		return {
-			value  : Dialect.escapeId(name) + " " + type.value,
+			value  : driver.query.escapeId(name) + " " + type.value,
 			before : type.before
 		};
 	};
@@ -122,16 +122,16 @@ function Sync(options) {
 
 				if (col.before) {
 					queue.add(col, function (col, next) {
-						col.before(db, function (err) {
+						col.before(driver, function (err) {
 							if (err) {
 								return next(err);
 							}
-							return Dialect.addCollectionColumn(db, collection.name, col.value, last_k, next);
+							return Dialect.addCollectionColumn(driver, collection.name, col.value, last_k, next);
 						});
 					});
 				} else {
 					queue.add(function (next) {
-						return Dialect.addCollectionColumn(db, collection.name, col.value, last_k, next);
+						return Dialect.addCollectionColumn(driver, collection.name, col.value, last_k, next);
 					});
 				}
 			} else if (needToSync(collection.properties[k], columns[k])) {
@@ -147,16 +147,16 @@ function Sync(options) {
 
 				if (col.before) {
 					queue.add(col, function (col, next) {
-						col.before(db, function (err) {
+						col.before(driver, function (err) {
 							if (err) {
 								return next(err);
 							}
-							return Dialect.modifyCollectionColumn(db, collection.name, col.value, next);
+							return Dialect.modifyCollectionColumn(driver, collection.name, col.value, next);
 						});
 					});
 				} else {
 					queue.add(function (next) {
-						return Dialect.modifyCollectionColumn(db, collection.name, col.value, next);
+						return Dialect.modifyCollectionColumn(driver, collection.name, col.value, next);
 					});
 				}
 			}
@@ -172,7 +172,7 @@ function Sync(options) {
 
                         total_changes += 1;
 
-                        return Dialect.dropCollectionColumn(db, collection.name, k, next);
+                        return Dialect.dropCollectionColumn(driver, collection.name, k, next);
                     });
                 }
             }
@@ -266,7 +266,7 @@ function Sync(options) {
 	};
 
 	var syncIndexes = function (name, indexes, cb) {
-		Dialect.getCollectionIndexes(db, name, function (err, db_indexes) {
+		Dialect.getCollectionIndexes(driver, name, function (err, db_indexes) {
 			if (err) return cb(err);
 
 			var queue = new Queue(cb);
@@ -278,7 +278,7 @@ function Sync(options) {
 					total_changes += 1;
 
 					queue.add(indexes[i], function (index, next) {
-						return Dialect.addIndex(db, index.name, index.unique, name, index.columns, next);
+						return Dialect.addIndex(driver, index.name, index.unique, name, index.columns, next);
 					});
 					continue;
 				} else if (!db_indexes[indexes[i].name].unique != !indexes[i].unique) {
@@ -287,10 +287,10 @@ function Sync(options) {
 					total_changes += 1;
 
 					queue.add(indexes[i], function (index, next) {
-						return Dialect.removeIndex(db, index.name, name, next);
+						return Dialect.removeIndex(driver, index.name, name, next);
 					});
 					queue.add(indexes[i], function (index, next) {
-						return Dialect.addIndex(db, index.name, index.unique, name, index.columns, next);
+						return Dialect.addIndex(driver, index.name, index.unique, name, index.columns, next);
 					});
 				}
 				delete db_indexes[indexes[i].name];
@@ -302,7 +302,7 @@ function Sync(options) {
 				total_changes += 1;
 
 				queue.add(i, function (index, next) {
-					return Dialect.removeIndex(db, index, name, next);
+					return Dialect.removeIndex(driver, index, name, next);
 				});
 			}
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name"            : "sql-ddl-sync",
 	"description"     : "NodeJS SQL DDL Synchronization",
 	"keywords"        : [ "sql", "ddl", "sync", "mysql", "postgres", "sqlite" ],
-	"version"         : "0.1.5",
+	"version"         : "0.2.0",
 	"license"         : "MIT",
 	"repository"      : "http://github.com/dresende/node-sql-ddl-sync.git",
 	"main"            : "./lib/Sync",
@@ -16,6 +16,7 @@
 	"devDependencies" : {
 		"mocha"         : "1.14.0",
 		"should"        : "2.0.2",
-		"commander"     : "~2.0.0"
+		"commander"     : "~2.0.0",
+		"orm"           : "git://github.com/dresende/node-orm2.git#new-sql-ddl-sync"
 	}
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,19 +1,24 @@
 exports.dialect = null;
 exports.table   = "sql_ddl_sync_test_table";
 
-exports.fakeDialect = {
-	escapeId : function (id) {
-		return "$$" + id + "$$";
+exports.fakeDriver = {
+	query: {
+		escapeId  : function (id) {
+			return "$$" + id + "$$";
+		},
+		escapeVal : function (val) {
+			return "^^" + val + "^^";
+		}
 	}
 };
 
 exports.dropColumn = function (column) {
 	return function (done) {
-		switch (exports.dialect) {
+		switch (exports.driver.dialect) {
 			case "mysql":
-				return exports.db.query("ALTER TABLE ?? DROP ??", [ exports.table, column ], done);
+				return exports.driver.execQuery("ALTER TABLE ?? DROP ??", [ exports.table, column ], done);
 			case "postgresql":
-				return exports.db.query("ALTER TABLE " + exports.table + " DROP " + column, done);
+				return exports.driver.execQuery("ALTER TABLE " + exports.table + " DROP " + column, done);
 		}
 		return done(unknownProtocol());
 	};
@@ -21,13 +26,13 @@ exports.dropColumn = function (column) {
 
 exports.addColumn = function (column) {
 	return function (done) {
-		switch (exports.dialect) {
+		switch (exports.driver.dialect) {
 			case "mysql":
-				return exports.db.query("ALTER TABLE ?? ADD ?? INTEGER NOT NULL", [ exports.table, column ], done);
+				return exports.driver.execQuery("ALTER TABLE ?? ADD ?? INTEGER NOT NULL", [ exports.table, column ], done);
 			case "postgresql":
-				return exports.db.query("ALTER TABLE " + exports.table + " ADD " + column + " INTEGER NOT NULL", done);
+				return exports.driver.execQuery("ALTER TABLE " + exports.table + " ADD " + column + " INTEGER NOT NULL", done);
 			case "sqlite":
-				return exports.db.all("ALTER TABLE " + exports.table + " ADD " + column + " INTEGER", done);
+				return exports.driver.execQuery("ALTER TABLE " + exports.table + " ADD " + column + " INTEGER", done);
 		}
 		return done(unknownProtocol());
 	};
@@ -35,13 +40,13 @@ exports.addColumn = function (column) {
 
 exports.changeColumn = function (column) {
 	return function (done) {
-		switch (exports.dialect) {
+		switch (exports.driver.dialect) {
 			case "mysql":
-				return exports.db.query("ALTER TABLE ?? MODIFY ?? INTEGER NOT NULL", [ exports.table, column ], done);
+				return exports.driver.execQuery("ALTER TABLE ?? MODIFY ?? INTEGER NOT NULL", [ exports.table, column ], done);
 			case "postgresql":
-				return exports.db.query("ALTER TABLE " + exports.table + " ALTER " + column + " TYPE DOUBLE PRECISION", done);
+				return exports.driver.execQuery("ALTER TABLE " + exports.table + " ALTER " + column + " TYPE DOUBLE PRECISION", done);
 			case "sqlite":
-				return exports.db.all("ALTER TABLE " + exports.table + " MODIFY " + column + " INTEGER NOT NULL", done);
+				return exports.driver.execQuery("ALTER TABLE " + exports.table + " MODIFY " + column + " INTEGER NOT NULL", done);
 		}
 		return done(unknownProtocol());
 	};
@@ -49,13 +54,13 @@ exports.changeColumn = function (column) {
 
 exports.addIndex = function (name, column, unique) {
 	return function (done) {
-		switch (exports.dialect) {
+		switch (exports.driver.dialect) {
 			case "mysql":
-				return exports.db.query("CREATE " + (unique ? "UNIQUE" : "") + " INDEX ?? ON ?? (??)", [ name, exports.table, column ], done);
+				return exports.driver.execQuery("CREATE " + (unique ? "UNIQUE" : "") + " INDEX ?? ON ?? (??)", [ name, exports.table, column ], done);
 			case "postgresql":
-				return exports.db.query("CREATE " + (unique ? "UNIQUE" : "") + " INDEX " + exports.table + "_" + name + " ON " + exports.table + " (" + column + ")", done);
+				return exports.driver.execQuery("CREATE " + (unique ? "UNIQUE" : "") + " INDEX " + exports.table + "_" + name + " ON " + exports.table + " (" + column + ")", done);
 			case "sqlite":
-				return exports.db.all("CREATE " + (unique ? "UNIQUE" : "") + " INDEX " + name + " ON " + exports.table + " (" + column + ")", done);
+				return exports.driver.execQuery("CREATE " + (unique ? "UNIQUE" : "") + " INDEX " + name + " ON " + exports.table + " (" + column + ")", done);
 		}
 		return done(unknownProtocol());
 	};
@@ -63,18 +68,18 @@ exports.addIndex = function (name, column, unique) {
 
 exports.dropIndex = function (name) {
 	return function (done) {
-		switch (exports.dialect) {
+		switch (exports.driver.dialect) {
 			case "mysql":
-				return exports.db.query("DROP INDEX ?? ON ??", [ name, exports.table ], done);
+				return exports.driver.execQuery("DROP INDEX ?? ON ??", [ name, exports.table ], done);
 			case "postgresql":
-				return exports.db.query("DROP INDEX " + exports.table + "_" + name, done);
+				return exports.driver.execQuery("DROP INDEX " + exports.table + "_" + name, done);
 			case "sqlite":
-				return exports.db.all("DROP INDEX " + name, done);
+				return exports.driver.execQuery("DROP INDEX " + name, done);
 		}
 		return done(unknownProtocol());
 	};
 };
 
 function unknownProtocol() {
-	return new Error("Unknown protocol - " + exports.dialect);
+	return new Error("Unknown protocol - " + exports.driver.dialect);
 }

--- a/test/integration/db.js
+++ b/test/integration/db.js
@@ -2,8 +2,7 @@ var Sync    = require("../../lib/Sync").Sync;
 var common  = require("../common");
 var should  = require("should");
 var sync    = new Sync({
-	dialect : common.dialect,
-	db      : common.db,
+	driver  : common.driver,
 	debug   : function (text) {
 		// console.log("> %s", text);
 	}

--- a/test/integration/mysql.js
+++ b/test/integration/mysql.js
@@ -1,72 +1,72 @@
+var should  = require("should");
 var common  = require("../common");
 var Dialect = require("../../lib/Dialects/mysql");
-
-var should  = require("should");
+var driver  = common.fakeDriver;
 
 describe("MySQL.getType", function () {
 	it("should detect text", function (done) {
-		Dialect.getType(null, null, { type: "text" }).value.should.equal("VARCHAR(255)");
-		Dialect.getType(null, null, { type: "text", size: 150 }).value.should.equal("VARCHAR(150)");
-		Dialect.getType(null, null, { type: "text", size: 1000 }).value.should.equal("VARCHAR(1000)");
+		Dialect.getType(null, null, { type: "text" }, driver).value.should.equal("VARCHAR(255)");
+		Dialect.getType(null, null, { type: "text", size: 150 }, driver).value.should.equal("VARCHAR(150)");
+		Dialect.getType(null, null, { type: "text", size: 1000 }, driver).value.should.equal("VARCHAR(1000)");
 
 		return done();
 	});
 
 	it("should detect numbers", function (done) {
-		Dialect.getType(null, null, { type: "number" }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 4 }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 2 }).value.should.equal("SMALLINT");
-		Dialect.getType(null, null, { type: "number", size: 8 }).value.should.equal("BIGINT");
+		Dialect.getType(null, null, { type: "number" }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 4 }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 2 }, driver).value.should.equal("SMALLINT");
+		Dialect.getType(null, null, { type: "number", size: 8 }, driver).value.should.equal("BIGINT");
 
 		return done();
 	});
 
 	it("should detect rational numbers", function (done) {
-		Dialect.getType(null, null, { type: "number", rational: true }).value.should.equal("FLOAT");
-		Dialect.getType(null, null, { type: "number", rational: true, size: 4 }).value.should.equal("FLOAT");
-		Dialect.getType(null, null, { type: "number", rational: true, size: 8 }).value.should.equal("DOUBLE");
+		Dialect.getType(null, null, { type: "number", rational: true }, driver).value.should.equal("FLOAT");
+		Dialect.getType(null, null, { type: "number", rational: true, size: 4 }, driver).value.should.equal("FLOAT");
+		Dialect.getType(null, null, { type: "number", rational: true, size: 8 }, driver).value.should.equal("DOUBLE");
 
 		return done();
 	});
 
 	it("should detect booleans", function (done) {
-		Dialect.getType(null, null, { type: "boolean" }).value.should.equal("TINYINT(1)");
+		Dialect.getType(null, null, { type: "boolean" }, driver).value.should.equal("TINYINT(1)");
 
 		return done();
 	});
 
 	it("should detect dates", function (done) {
-		Dialect.getType(null, null, { type: "date" }).value.should.equal("DATE");
+		Dialect.getType(null, null, { type: "date" }, driver).value.should.equal("DATE");
 
 		return done();
 	});
 
 	it("should detect dates with times", function (done) {
-		Dialect.getType(null, null, { type: "date", time: true }).value.should.equal("DATETIME");
+		Dialect.getType(null, null, { type: "date", time: true }, driver).value.should.equal("DATETIME");
 
 		return done();
 	});
 
 	it("should detect binary", function (done) {
-		Dialect.getType(null, null, { type: "binary" }).value.should.equal("BLOB");
+		Dialect.getType(null, null, { type: "binary" }, driver).value.should.equal("BLOB");
 
 		return done();
 	});
 
 	it("should detect big binary", function (done) {
-		Dialect.getType(null, null, { type: "binary", big: true }).value.should.equal("LONGBLOB");
+		Dialect.getType(null, null, { type: "binary", big: true }, driver).value.should.equal("LONGBLOB");
 
 		return done();
 	});
 
 	it("should detect required items", function (done) {
-		Dialect.getType(null, null, { type: "boolean", required: true }).value.should.match(/NOT NULL/);
+		Dialect.getType(null, null, { type: "boolean", required: true }, driver).value.should.match(/NOT NULL/);
 
 		return done();
 	});
 
 	it("should detect default values", function (done) {
-		Dialect.getType(null, null, { type: "number", defaultValue: 3 }).value.should.match(/DEFAULT 3/);
+		Dialect.getType(null, null, { type: "number", defaultValue: 3 }, driver).value.should.match(/DEFAULT \^\^3\^\^/);
 
 		return done();
 	});
@@ -80,16 +80,6 @@ describe("MySQL.getType", function () {
 		column.should.match(/INT/);
 		column.should.match(/NOT NULL/);
 		column.should.match(/AUTO_INCREMENT/);
-
-		return done();
-	});
-});
-
-describe("MySQL.escapeId", function () {
-	it("should correctly escape identifiers", function (done) {
-		Dialect.escapeId("my_id").should.equal("`my_id`");
-		Dialect.escapeId("my_`id").should.equal("`my_``id`");
-		Dialect.escapeId("my_id", "sub").should.equal("`my_id`.`sub`");
 
 		return done();
 	});

--- a/test/integration/postgresql.js
+++ b/test/integration/postgresql.js
@@ -1,76 +1,66 @@
+var should  = require("should");
 var common  = require("../common");
 var Dialect = require("../../lib/Dialects/postgresql");
-
-var should  = require("should");
+var driver  = common.fakeDriver;
 
 describe("PostgreSQL.getType", function () {
 	it("should detect text", function (done) {
-		Dialect.getType(null, null, { type: "text" }).value.should.equal("TEXT");
-		Dialect.getType(null, null, { type: "text", size: 150 }).value.should.equal("TEXT");
-		Dialect.getType(null, null, { type: "text", size: 1000 }).value.should.equal("TEXT");
+		Dialect.getType(null, null, { type: "text" }, driver).value.should.equal("TEXT");
+		Dialect.getType(null, null, { type: "text", size: 150 }, driver).value.should.equal("TEXT");
+		Dialect.getType(null, null, { type: "text", size: 1000 }, driver).value.should.equal("TEXT");
 
 		return done();
 	});
 
 	it("should detect numbers", function (done) {
-		Dialect.getType(null, null, { type: "number" }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 4 }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 2 }).value.should.equal("SMALLINT");
-		Dialect.getType(null, null, { type: "number", size: 8 }).value.should.equal("BIGINT");
+		Dialect.getType(null, null, { type: "number" }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 4 }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 2 }, driver).value.should.equal("SMALLINT");
+		Dialect.getType(null, null, { type: "number", size: 8 }, driver).value.should.equal("BIGINT");
 
 		return done();
 	});
 
 	it("should detect rational numbers", function (done) {
-		Dialect.getType(null, null, { type: "number", rational: true }).value.should.equal("REAL");
-		Dialect.getType(null, null, { type: "number", rational: true, size: 4 }).value.should.equal("REAL");
-		Dialect.getType(null, null, { type: "number", rational: true, size: 8 }).value.should.equal("DOUBLE PRECISION");
+		Dialect.getType(null, null, { type: "number", rational: true }, driver).value.should.equal("REAL");
+		Dialect.getType(null, null, { type: "number", rational: true, size: 4 }, driver).value.should.equal("REAL");
+		Dialect.getType(null, null, { type: "number", rational: true, size: 8 }, driver).value.should.equal("DOUBLE PRECISION");
 
 		return done();
 	});
 
 	it("should detect booleans", function (done) {
-		Dialect.getType(null, null, { type: "boolean" }).value.should.equal("BOOLEAN");
+		Dialect.getType(null, null, { type: "boolean" }, driver).value.should.equal("BOOLEAN");
 
 		return done();
 	});
 
 	it("should detect dates", function (done) {
-		Dialect.getType(null, null, { type: "date" }).value.should.equal("DATE");
+		Dialect.getType(null, null, { type: "date" }, driver).value.should.equal("DATE");
 
 		return done();
 	});
 
 	it("should detect dates with times", function (done) {
-		Dialect.getType(null, null, { type: "date", time: true }).value.should.equal("TIMESTAMP WITHOUT TIME ZONE");
+		Dialect.getType(null, null, { type: "date", time: true }, driver).value.should.equal("TIMESTAMP WITHOUT TIME ZONE");
 
 		return done();
 	});
 
 	it("should detect binary", function (done) {
-		Dialect.getType(null, null, { type: "binary" }).value.should.equal("BYTEA");
+		Dialect.getType(null, null, { type: "binary" }, driver).value.should.equal("BYTEA");
 
 		return done();
 	});
 
 	it("should detect required items", function (done) {
-		Dialect.getType(null, null, { type: "boolean", required: true }).value.should.match(/NOT NULL/);
+		Dialect.getType(null, null, { type: "boolean", required: true }, driver).value.should.match(/NOT NULL/);
 
 		return done();
 	});
 
 	it("should detect default values", function (done) {
-		Dialect.getType(null, null, { type: "number", defaultValue: 3 }).value.should.match(/DEFAULT 3/);
-
-		return done();
-	});
-});
-
-describe("PostgreSQL.escapeId", function () {
-	it("should correctly escape identifiers", function (done) {
-		Dialect.escapeId("my_id").should.equal('"my_id"');
-		Dialect.escapeId("my_\"id").should.equal('"my_""id"');
-		Dialect.escapeId("my_id", "sub").should.equal('"my_id"."sub"');
+		Dialect.getType(null, null, { type: "number", defaultValue: 3 }, driver).value.should.match(/DEFAULT \^\^3\^\^/);
 
 		return done();
 	});

--- a/test/integration/sql.js
+++ b/test/integration/sql.js
@@ -1,9 +1,7 @@
+var should  = require("should");
 var common  = require("../common");
 var SQL     = require("../../lib/SQL");
-
-var should  = require("should");
-
-var Dialect = common.fakeDialect;
+var driver  = common.fakeDriver;
 
 describe("SQL.CREATE_TABLE", function () {
 	it("should return a CREATE TABLE", function (done) {
@@ -11,7 +9,7 @@ describe("SQL.CREATE_TABLE", function () {
 			name    : "fake_table",
 			columns : [ "first_fake_column", "second_fake_column" ],
 			keys    : [ "my_primary_key" ]
-		}, Dialect).should.equal("CREATE TABLE $$fake_table$$ (first_fake_column, second_fake_column, " +
+		}, driver).should.equal("CREATE TABLE $$fake_table$$ (first_fake_column, second_fake_column, " +
 		                         "PRIMARY KEY ($$my_primary_key$$))");
 
 		return done();
@@ -23,7 +21,7 @@ describe("SQL.CREATE_TABLE", function () {
 		SQL.CREATE_TABLE({
 			name    : "fake_table",
 			columns : [ "first_fake_column", "second_fake_column" ]
-		}, Dialect).should.equal("CREATE TABLE $$fake_table$$ (first_fake_column, second_fake_column)");
+		}, driver).should.equal("CREATE TABLE $$fake_table$$ (first_fake_column, second_fake_column)");
 
 		return done();
 	});
@@ -33,7 +31,7 @@ describe("SQL.DROP_TABLE", function () {
 	it("should return a DROP TABLE", function (done) {
 		SQL.DROP_TABLE({
 			name    : "fake_table"
-		}, Dialect).should.equal("DROP TABLE $$fake_table$$");
+		}, driver).should.equal("DROP TABLE $$fake_table$$");
 
 		return done();
 	});
@@ -45,7 +43,7 @@ describe("SQL.ALTER_TABLE_ADD_COLUMN", function () {
 		SQL.ALTER_TABLE_ADD_COLUMN({
 			name    : "fake_table",
 			column  : "my_fake_column"
-		}, Dialect).should.equal("ALTER TABLE $$fake_table$$ ADD my_fake_column");
+		}, driver).should.equal("ALTER TABLE $$fake_table$$ ADD my_fake_column");
 
 		return done();
 	});
@@ -57,7 +55,7 @@ describe("SQL.ALTER_TABLE_ADD_COLUMN", function () {
 			name    : "fake_table",
 			column  : "my_fake_column",
 			first   : true
-		}, Dialect).should.equal("ALTER TABLE $$fake_table$$ ADD my_fake_column FIRST");
+		}, driver).should.equal("ALTER TABLE $$fake_table$$ ADD my_fake_column FIRST");
 
 		return done();
 	});
@@ -69,7 +67,7 @@ describe("SQL.ALTER_TABLE_ADD_COLUMN", function () {
 			name    : "fake_table",
 			column  : "my_fake_column",
 			after   : "other_column"
-		}, Dialect).should.equal("ALTER TABLE $$fake_table$$ ADD my_fake_column AFTER $$other_column$$");
+		}, driver).should.equal("ALTER TABLE $$fake_table$$ ADD my_fake_column AFTER $$other_column$$");
 
 		return done();
 	});
@@ -80,7 +78,7 @@ describe("SQL.ALTER_TABLE_MODIFY_COLUMN", function () {
 		SQL.ALTER_TABLE_MODIFY_COLUMN({
 			name    : "fake_table",
 			column  : "my_fake_column"
-		}, Dialect).should.equal("ALTER TABLE $$fake_table$$ MODIFY my_fake_column");
+		}, driver).should.equal("ALTER TABLE $$fake_table$$ MODIFY my_fake_column");
 
 		return done();
 	});
@@ -91,7 +89,7 @@ describe("SQL.ALTER_TABLE_DROP_COLUMN", function () {
 		SQL.ALTER_TABLE_DROP_COLUMN({
 			name    : "fake_table",
 			column  : "my_fake_column"
-		}, Dialect).should.equal("ALTER TABLE $$fake_table$$ DROP $$my_fake_column$$");
+		}, driver).should.equal("ALTER TABLE $$fake_table$$ DROP $$my_fake_column$$");
 
 		return done();
 	});
@@ -103,7 +101,7 @@ describe("SQL.CREATE_INDEX", function () {
 			name       : "fake_index",
 			collection : "fake_table",
 			columns    : [ "my_fake_column" ]
-		}, Dialect).should.equal("CREATE INDEX $$fake_index$$ ON $$fake_table$$ ($$my_fake_column$$)");
+		}, driver).should.equal("CREATE INDEX $$fake_index$$ ON $$fake_table$$ ($$my_fake_column$$)");
 
 		return done();
 	});
@@ -114,7 +112,7 @@ describe("SQL.CREATE_INDEX", function () {
 			collection : "fake_table",
 			unique     : true,
 			columns    : [ "my_fake_column" ]
-		}, Dialect).should.equal("CREATE UNIQUE INDEX $$fake_index$$ ON $$fake_table$$ ($$my_fake_column$$)");
+		}, driver).should.equal("CREATE UNIQUE INDEX $$fake_index$$ ON $$fake_table$$ ($$my_fake_column$$)");
 
 		return done();
 	});
@@ -125,7 +123,7 @@ describe("SQL.DROP_INDEX", function () {
 		SQL.DROP_INDEX({
 			name       : "fake_index",
 			collection : "fake_table"
-		}, Dialect).should.equal("DROP INDEX $$fake_index$$ ON $$fake_table$$");
+		}, driver).should.equal("DROP INDEX $$fake_index$$ ON $$fake_table$$");
 
 		return done();
 	});

--- a/test/integration/sqlite.js
+++ b/test/integration/sqlite.js
@@ -1,61 +1,61 @@
+var should  = require("should");
 var common  = require("../common");
 var Dialect = require("../../lib/Dialects/sqlite");
-
-var should  = require("should");
+var driver  = common.fakeDriver;
 
 describe("SQLite.getType", function () {
 	it("should detect text", function (done) {
-		Dialect.getType(null, null, { type: "text" }).value.should.equal("TEXT");
-		Dialect.getType(null, null, { type: "text", size: 150 }).value.should.equal("TEXT");
+		Dialect.getType(null, null, { type: "text" }, driver).value.should.equal("TEXT");
+		Dialect.getType(null, null, { type: "text", size: 150 }, driver).value.should.equal("TEXT");
 
 		return done();
 	});
 
 	it("should detect numbers", function (done) {
-		Dialect.getType(null, null, { type: "number" }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 4 }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 2 }).value.should.equal("INTEGER");
-		Dialect.getType(null, null, { type: "number", size: 8 }).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number" }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 4 }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 2 }, driver).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "number", size: 8 }, driver).value.should.equal("INTEGER");
 
 		return done();
 	});
 
 	it("should detect rational numbers", function (done) {
-		Dialect.getType(null, null, { type: "number", rational: true }).value.should.equal("REAL");
-		Dialect.getType(null, null, { type: "number", rational: true, size: 4 }).value.should.equal("REAL");
-		Dialect.getType(null, null, { type: "number", rational: true, size: 8 }).value.should.equal("REAL");
+		Dialect.getType(null, null, { type: "number", rational: true }, driver).value.should.equal("REAL");
+		Dialect.getType(null, null, { type: "number", rational: true, size: 4 }, driver).value.should.equal("REAL");
+		Dialect.getType(null, null, { type: "number", rational: true, size: 8 }, driver).value.should.equal("REAL");
 
 		return done();
 	});
 
 	it("should detect booleans", function (done) {
-		Dialect.getType(null, null, { type: "boolean" }).value.should.equal("INTEGER");
+		Dialect.getType(null, null, { type: "boolean" }, driver).value.should.equal("INTEGER");
 
 		return done();
 	});
 
 	it("should detect dates", function (done) {
-		Dialect.getType(null, null, { type: "date" }).value.should.equal("DATETIME");
-		Dialect.getType(null, null, { type: "date", time: true }).value.should.equal("DATETIME");
+		Dialect.getType(null, null, { type: "date" }, driver).value.should.equal("DATETIME");
+		Dialect.getType(null, null, { type: "date", time: true }, driver).value.should.equal("DATETIME");
 
 		return done();
 	});
 
 	it("should detect binary", function (done) {
-		Dialect.getType(null, null, { type: "binary" }).value.should.equal("BLOB");
-		Dialect.getType(null, null, { type: "binary", big: true }).value.should.equal("BLOB");
+		Dialect.getType(null, null, { type: "binary" }, driver).value.should.equal("BLOB");
+		Dialect.getType(null, null, { type: "binary", big: true }, driver).value.should.equal("BLOB");
 
 		return done();
 	});
 
 	it("should detect required items", function (done) {
-		Dialect.getType(null, null, { type: "boolean", required: true }).value.should.match(/NOT NULL/);
+		Dialect.getType(null, null, { type: "boolean", required: true }, driver).value.should.match(/NOT NULL/);
 
 		return done();
 	});
 
 	it("should detect default values", function (done) {
-		Dialect.getType(null, null, { type: "number", defaultValue: 3 }).value.should.match(/DEFAULT 3/);
+		Dialect.getType(null, null, { type: "number", defaultValue: 3 }, driver).value.should.match(/DEFAULT \^\^3\^\^/);
 
 		return done();
 	});
@@ -68,16 +68,6 @@ describe("SQLite.getType", function () {
 
 		column.should.match(/INT/);
 		column.should.match(/AUTOINCREMENT/);
-
-		return done();
-	});
-});
-
-describe("SQLite.escapeId", function () {
-	it("should correctly escape identifiers", function (done) {
-		Dialect.escapeId("my_id").should.equal("`my_id`");
-		Dialect.escapeId("my_`id").should.equal("`my_``id`");
-		Dialect.escapeId("my_id", "sub").should.equal("`my_id`.`sub`");
 
 		return done();
 	});


### PR DESCRIPTION
This will fix issues like dresende/node-orm2#416.
It encourages code reuse rather than copying and pasting from other packages.
It reuses driver functionality from ORM to make life easier.

See dresende/node-orm2#434

This is a significant change, however I believe it moves things in the right direction.
