### PR TITLE
Fix error with similar table names across databases

### DIFF
--- a/lib/Dialects/mysql.js
+++ b/lib/Dialects/mysql.js
@@ -184,9 +184,9 @@ exports.getCollectionIndexes = function (driver, name, cb) {
 	var q = "";
 	q += "SELECT index_name, column_name, non_unique ";
 	q += "FROM information_schema.statistics ";
-	q += "WHERE table_name = ?";
+	q += "WHERE table_schema = ? AND table_name = ?";
 
-	driver.execQuery(q, [name], function (err, rows) {
+	driver.execQuery(q, [driver.config.database, name], function (err, rows) {
 		if (err) return cb(err);
 
 		return cb(null, convertIndexRows(rows));


### PR DESCRIPTION
If the same table name exists across multiple databases the sync command can error out and fail the sync procedure. Conflicts with indexes can occur.
