### PR TITLE
Fix: option 'defaultValue' for 'date' property should set 'DEFAULT = now() 

### DIFF
--- a/lib/Dialects/postgresql.js
+++ b/lib/Dialects/postgresql.js
@@ -326,7 +326,11 @@ exports.getType = function (collection, property, driver) {
 			type += " NOT NULL";
 		}
 		if (property.hasOwnProperty("defaultValue")) {
-			type += " DEFAULT " + driver.query.escapeVal(property.defaultValue);
+			if (property.type == 'date' && property.defaultValue === Date.now ){
+				type += " DEFAULT now()";
+			} else {
+				type += " DEFAULT " + driver.query.escapeVal(property.defaultValue);
+			}
 		}
 	}
 


### PR DESCRIPTION
consider a model

``` js
Project.hasMany('members',
        User,
        { since: {  type: 'date',
                    time: true,
                    defaultValue: Date.now
                 }},
        { reverse: 'projects'} );

```

I gets an error 'column "since" is of type timestamp without time zone but default expression is of type bigint' while syncing the databse with my postgresSql db
setting

``` js
defaultValue =  function(){ return new Date(); }
```

didn't solved the problem. So I fixed it. 
I am not sure whether it is the right method 
